### PR TITLE
Refactor handlers to avoid shell execution

### DIFF
--- a/Beacon.nim
+++ b/Beacon.nim
@@ -704,10 +704,11 @@ when defined(linux):
           continue
         let localAddr = parseAddress(parts[1])
         let remoteAddr = parseAddress(parts[2])
-        let stateIdx = try:
-          parseHexInt(parts[3])
-        except CatchableError:
-          0
+        let stateIdx =
+          try:
+            parseHexInt(parts[3])
+          except CatchableError:
+            0
         let state = if stateIdx < tcpStates.len: tcpStates[stateIdx] else: tcpStates[0]
         output.add(fmt"{proto}\t{localAddr}\t{remoteAddr}\t{state}")
     except CatchableError:


### PR DESCRIPTION
## Summary
- replace directory listing with direct filesystem enumeration and formatted output
- implement native process listing, process termination, command execution, user lookup, netstat, ip configuration, and share enumeration without spawning shells
- add platform-specific helpers for Linux `/proc` parsing and Windows Toolhelp/NetAPI usage

## Testing
- nim c --compileOnly Beacon.nim *(fails: Nim compiler not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e2ab5fd0ec83258d8f6c089bfe2e7e